### PR TITLE
Bugfix/task 01

### DIFF
--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,10 +19,11 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import { formatDateTime, formatLocalDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -116,6 +117,7 @@ function Header({ launch }) {
 function TimeAndLocation({ launch }) {
   return (
     <SimpleGrid columns={[1, 1, 2]} borderWidth="1px" p="4" borderRadius="md">
+
       <Stat>
         <StatLabel display="flex">
           <Box as={Watch} width="1em" />{" "}
@@ -124,10 +126,14 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          <Tooltip placement='bottom-start' label={formatDateTime(launch.launch_date_local)} aria-label='tooltip-date'>
+            {formatLocalDateTime(launch.launch_date_local)}
+          </Tooltip>
         </StatNumber>
+
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>
+
       <Stat>
         <StatLabel display="flex">
           <Box as={MapPin} width="1em" />{" "}

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -18,3 +18,17 @@ export function formatDateTime(timestamp) {
     timeZoneName: "short",
   }).format(new Date(timestamp));
 }
+
+/*
+function which returns date in string format without affecting the original timezone
+aka beautify the string
+*/
+export function formatLocalDateTime(timestamp){
+  var dateArr = timestamp.split('T');
+  var time = dateArr[1].substring(0,8);
+  var offset = dateArr[1].substring(8);
+  
+  var finalDate = `${dateArr[0]}, ${time}, GMT ${offset}`;
+  return finalDate;
+
+}


### PR DESCRIPTION
## Bug description
### Component
launch details page (e.g. /launches/92) 
### Current behaviour
The date is displayed in the timezone of the app's user
### Desired behaviour
Keep the time in the user's timezone as a tooltip when hovering the timestamp displayed in local timezone of the launch site

## Approach

If we parse the local time string to a date object (using new Date), JS automatically translates the timezone and the initial timezone offset is lost - thus we need to manually beautify the string. 
Created a new function in Utils which beautifies the local date string and does not modify the timezone of the date to user's timezone. Also, added a tooltip which presents the date time in the user's timezone.

Of course, the string 'beautification' can be improved to match the DateTimeFormat of localized timezone date.

## Screenshots of solution
### Before
<img width="671" alt="image" src="https://user-images.githubusercontent.com/24357659/162982635-f38d57f4-abb0-4d6a-b188-6a79dfaeb819.png">

### After

<img width="470" alt="image" src="https://user-images.githubusercontent.com/24357659/162982862-2307eaa9-ddb5-406b-9678-5b98fb107e4a.png">




